### PR TITLE
Feature/#20 avatar ui -  아바타 컴포넌트 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,5 +75,5 @@ dependencies {
     implementation hiltDependencies.implementation.values()
     kapt hiltDependencies.kapt.values()
 
-    implementation glideDependencies.implementation.values()
+    implementation imageDependencies.implementation.values()
 }

--- a/core_ui/build.gradle
+++ b/core_ui/build.gradle
@@ -46,4 +46,6 @@ dependencies {
 
     implementation composeDependencies.implementation.values()
     debugImplementation composeDependencies.debugImplementation.values()
+
+    implementation imageDependencies.implementation.values()
 }

--- a/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
+++ b/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
@@ -48,7 +48,7 @@ fun Avatar(
 }
 
 @Composable
-fun MoreAvatar(
+internal fun MoreAvatar(
         overflowCount: Int,
         width: Dp,
         height: Dp,
@@ -134,7 +134,7 @@ fun AvatarList(
 
 @Composable
 @Preview(showBackground = true)
-fun AvatarPreview() {
+internal fun AvatarPreview() {
     Box(
             modifier = Modifier
                     .size(100.dp)
@@ -153,7 +153,7 @@ fun AvatarPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun AvatarListPreview() {
+internal fun AvatarListPreview() {
     Box(
             modifier = Modifier
                     .size(width = 300.dp, height = 100.dp)
@@ -178,7 +178,7 @@ fun AvatarListPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun AvatarListMorePreview() {
+internal fun AvatarListMorePreview() {
     Box(
             modifier = Modifier
                     .size(width = 300.dp, height = 100.dp)

--- a/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
+++ b/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
@@ -1,0 +1,200 @@
+package com.jyp.jyp_design.ui.avatar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.*
+import com.jyp.jyp_design.resource.JypColors
+import com.jyp.jyp_design.R
+import com.skydoves.landscapist.glide.GlideImage
+
+@Composable
+fun Avatar(
+        profileImageUrl: String,
+        width: Dp,
+        height: Dp,
+        showBorder: Boolean,
+        borderColor: Color,
+) {
+    GlideImage(
+            modifier = Modifier
+                    .size(width = width, height = height)
+                    .clip(RoundedCornerShape(12.dp))
+                    .let { modifier ->
+                        if (showBorder) {
+                            modifier.border(
+                                    width = 1.dp,
+                                    color = borderColor,
+                                    shape = RoundedCornerShape(12.dp),
+                            )
+                        } else {
+                            modifier
+                        }
+                    },
+            imageModel = profileImageUrl,
+            previewPlaceholder = R.drawable.ic_search,
+    )
+}
+
+@Composable
+fun MoreAvatar(
+        overflowCount: Int,
+        width: Dp,
+        height: Dp,
+        showBorder: Boolean,
+        borderColor: Color,
+) {
+    Box(
+            modifier = Modifier
+                    .size(width = width, height = height)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(color = JypColors.Background_grey300)
+                    .let { modifier ->
+                        if (showBorder) {
+                            modifier.border(
+                                    width = 1.dp,
+                                    color = borderColor,
+                                    shape = RoundedCornerShape(12.dp),
+                            )
+                        } else {
+                            modifier
+                        }
+                    },
+            contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+                modifier = Modifier
+                        .padding(start = 9.dp),
+                text = "$overflowCount+",
+                color = JypColors.Text_white,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+fun AvatarList(
+        profileImageUrls: List<String>,
+        width: Dp,
+        height: Dp,
+        showBorder: Boolean,
+        borderColor: Color,
+) {
+    val overflowCount: Int = profileImageUrls.size - 4
+
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        Row(
+                horizontalArrangement = Arrangement.spacedBy((-18).dp),
+        ) {
+            if (overflowCount > 0) {
+                MoreAvatar(
+                        overflowCount = overflowCount + 1,
+                        width = width,
+                        height = height,
+                        showBorder = showBorder,
+                        borderColor = borderColor,
+                )
+
+                profileImageUrls.subList(0, 3).forEach { url ->
+                    Avatar(
+                            profileImageUrl = url,
+                            width = width,
+                            height = height,
+                            showBorder = showBorder,
+                            borderColor = borderColor,
+                    )
+                }
+            } else {
+                profileImageUrls.forEach { url ->
+                    Avatar(
+                            profileImageUrl = url,
+                            width = width,
+                            height = height,
+                            showBorder = showBorder,
+                            borderColor = borderColor,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun AvatarPreview() {
+    Box(
+            modifier = Modifier
+                    .size(100.dp)
+                    .background(JypColors.Background_grey300),
+            contentAlignment = Alignment.Center,
+    ) {
+        Avatar(
+                profileImageUrl = "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                width = 44.dp,
+                height = 44.dp,
+                showBorder = true,
+                borderColor = JypColors.Background_white100,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun AvatarListPreview() {
+    Box(
+            modifier = Modifier
+                    .size(width = 300.dp, height = 100.dp)
+                    .background(JypColors.Background_grey300),
+            contentAlignment = Alignment.CenterStart,
+    ) {
+        AvatarList(
+                profileImageUrls = listOf(
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                ),
+                width = 44.dp,
+                height = 44.dp,
+                showBorder = true,
+                borderColor = JypColors.Background_white100,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun AvatarListMorePreview() {
+    Box(
+            modifier = Modifier
+                    .size(width = 300.dp, height = 100.dp)
+                    .background(JypColors.Background_grey300),
+            contentAlignment = Alignment.CenterStart,
+    ) {
+        AvatarList(
+                profileImageUrls = listOf(
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                ),
+                width = 44.dp,
+                height = 44.dp,
+                showBorder = true,
+                borderColor = JypColors.Background_white100,
+        )
+    }
+}

--- a/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
+++ b/core_ui/src/main/java/com/jyp/jyp_design/ui/avatar/Avatar.kt
@@ -91,8 +91,9 @@ fun AvatarList(
         height: Dp,
         showBorder: Boolean,
         borderColor: Color,
+        limitListCount: Int = Int.MAX_VALUE,
 ) {
-    val overflowCount: Int = profileImageUrls.size - 4
+    val overflowCount: Int = profileImageUrls.size - limitListCount
 
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
         Row(
@@ -165,6 +166,7 @@ fun AvatarListPreview() {
                         "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
                         "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
                         "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
+                        "https://file.mk.co.kr/meet/neds/2021/04/image_readtop_2021_330747_16177500644599916.jpg",
                 ),
                 width = 44.dp,
                 height = 44.dp,
@@ -195,6 +197,7 @@ fun AvatarListMorePreview() {
                 height = 44.dp,
                 showBorder = true,
                 borderColor = JypColors.Background_white100,
+                limitListCount = 4,
         )
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ ext {
             compose_version           : "1.1.1",
             compose_activity_version  : "1.5.0",
             compose_navigation_version: "2.5.1",
+            landscapist_version       : "1.4.9",
     ]
 
     composeDependencies = [
@@ -41,9 +42,9 @@ ext {
             ],
     ]
 
-    glideDependencies = [
+    imageDependencies = [
             implementation: [
-                    glide_core: "com.github.bumptech.glide:glide:$versions.glide_version",
+                    landscapist_glide: "com.github.skydoves:landscapist-glide:$versions.landscapist_version",
             ],
     ]
 }


### PR DESCRIPTION
실제 프로필 이미지를 어떻게 보관하고 있을지 잘 모르겠어서 구체적인 속성은 넣지 않고 추가했어

아래 케이스는 구현을 해두었구
<img width="190" alt="스크린샷 2022-08-07 오후 4 47 32" src="https://user-images.githubusercontent.com/37904970/183280837-24e21390-7bb5-48a5-afb7-6cc606cf148d.png">

여기서 맨 앞에 아이콘 나오는 케이스는 컴포넌트에 추가하는것보다 직접 구성할 때 넣는게 더 적합할것 같아서 구현하지 않았어
<img width="244" alt="스크린샷 2022-08-07 오후 4 51 49" src="https://user-images.githubusercontent.com/37904970/183280975-60dc70c2-f58c-4402-a5ba-1192ca6541d7.png">

