### PR TITLE
 feature/#40 jyp text button default padding - 기본 패딩 제거

### DIFF
--- a/core_ui/src/main/java/com/jyp/jyp_design/ui/button/JypTextButton.kt
+++ b/core_ui/src/main/java/com/jyp/jyp_design/ui/button/JypTextButton.kt
@@ -1,6 +1,7 @@
 package com.jyp.jyp_design.ui.button
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
@@ -38,7 +39,8 @@ fun JypTextButton(
         },
         colors = ButtonDefaults.textButtonColors(
             backgroundColor = buttonColorSet.backgroundColor
-        )
+        ),
+        contentPadding = PaddingValues(0.dp),
     ) {
         JypText(
             text = text,


### PR DESCRIPTION
Material 패딩이 적용되어 있어서 디자인이랑 스펙을 맞추기가 어려워가지구 기본 padding을 제거할게!