### PR TITLE
Feature/#102 planner api - 플래너 화면 데이터 정상 표시되도록 변경

### DIFF
--- a/feature_planner/build.gradle
+++ b/feature_planner/build.gradle
@@ -41,6 +41,7 @@ android {
 dependencies {
     implementation project(':core_ui')
     implementation project(':core_network')
+    implementation project(':core_util')
     implementation project(':feature_add_place')
 
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteActivity.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.jyp.core_util.extensions.secondToDate
 import com.jyp.jyp_design.ui.gnb.GlobalNavigationBarColor
 import com.jyp.jyp_design.ui.gnb.GlobalNavigationBarLayout
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,6 +35,7 @@ class AddPlannerRouteActivity : ComponentActivity() {
     companion object {
         const val EXTRA_JOURNEY_ID = "EXTRA_JOURNEY_ID"
         const val EXTRA_DAY_INDEX = "EXTRA_DAY_INDEX"
+        const val EXTRA_START_DATE = "EXTRA_START_DATE"
         const val EXTRA_PIKMIS = "EXTRA_PIKMIS"
         const val EXTRA_PIKIS = "EXTRA_PIKIS"
     }
@@ -46,13 +48,14 @@ private fun Screen(
 ) {
     val pikmis by viewModel.pikmis.collectAsState()
     val pikis by viewModel.pikis.collectAsState()
+    val currentDate by viewModel.currentDate.collectAsState()
 
     GlobalNavigationBarLayout(
         color = GlobalNavigationBarColor.WHITE,
         title = "Day1",
         titleFontWeight = FontWeight.SemiBold,
         titleSize = 20.sp,
-        description = "7월 18일",
+        description = currentDate.secondToDate("M월 d일"),
         backAction = onClickBackAction,
         activeBack = true,
     ) {

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,6 +20,9 @@ class AddPlannerRouteViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val setPikisUseCase: SetPikisUseCase,
 ) : ViewModel() {
+    private val journeyId: String? = savedStateHandle[AddPlannerRouteActivity.EXTRA_JOURNEY_ID]
+    private val dayIndex: Int = savedStateHandle[AddPlannerRouteActivity.EXTRA_DAY_INDEX] ?: 0
+
     private val _pikmis: MutableStateFlow<List<PlannerPikme>> =
         MutableStateFlow(savedStateHandle[AddPlannerRouteActivity.EXTRA_PIKMIS] ?: emptyList())
 
@@ -31,8 +35,15 @@ class AddPlannerRouteViewModel @Inject constructor(
     val pikis: StateFlow<List<PlannerPiki>>
         get() = _pikis
 
-    private val journeyId: String? = savedStateHandle[AddPlannerRouteActivity.EXTRA_JOURNEY_ID]
-    private val dayIndex: Int? = savedStateHandle[AddPlannerRouteActivity.EXTRA_DAY_INDEX]
+    private val _currentDate =
+        MutableStateFlow(
+            (savedStateHandle.get<Long>(
+                AddPlannerRouteActivity.EXTRA_START_DATE
+            ) ?: 0) + TimeUnit.DAYS.toSeconds(dayIndex.toLong())
+        )
+
+    val currentDate: StateFlow<Long>
+        get() = _currentDate
 
     fun addPiki(pikme: PlannerPikme) {
         _pikis.value = pikis.value + PlannerPiki(

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerActivity.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerActivity.kt
@@ -57,6 +57,7 @@ class PlannerActivity : ComponentActivity() {
 
                             putExtra(AddPlannerRouteActivity.EXTRA_JOURNEY_ID, plannerId)
                             putExtra(AddPlannerRouteActivity.EXTRA_DAY_INDEX, index)
+                            putExtra(AddPlannerRouteActivity.EXTRA_START_DATE, viewModel.plannerDates.value.first)
                         }
                     )
                 },

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerActivity.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerActivity.kt
@@ -87,6 +87,7 @@ private fun Screen(
     onNewPikMeClick: () -> Unit,
     onClickBackButton: () -> Unit,
 ) {
+    val plannerTitle by viewModel.plannerTitle.collectAsState()
     val plannerDates by viewModel.plannerDates.collectAsState()
     val pikMes by viewModel.pikmis.collectAsState()
     val tags by viewModel.tags.collectAsState()
@@ -114,6 +115,7 @@ private fun Screen(
             modifier = Modifier.fillMaxSize()
         ) {
             PlannerScreen(
+                plannerTitle = plannerTitle,
                 startDate = plannerDates.first,
                 endDate = plannerDates.second,
                 pikMes = pikMes,

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerJourneyPlanScreen.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerJourneyPlanScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.jyp.core_network.jyp.model.enumerate.PlaceCategory
 import com.jyp.core_network.jyp.model.enumerate.getDrawableResourceId
+import com.jyp.core_util.extensions.secondToDate
 import com.jyp.feature_planner.R
 import com.jyp.feature_planner.domain.PlannerPiki
 import com.jyp.feature_planner.presentation.planner.model.PlanItem
@@ -29,10 +30,12 @@ import com.jyp.jyp_design.resource.JypColors
 import com.jyp.jyp_design.resource.JypPainter
 import com.jyp.jyp_design.ui.text.JypText
 import com.jyp.jyp_design.ui.typography.type.TextType
+import java.util.concurrent.TimeUnit
 
 @Composable
 internal fun PlannerJourneyPlanScreen(
     planItems: List<PlanItem>,
+    startDate: Long,
     onClickEditRoute: (day: Int) -> Unit,
 ) {
     LazyColumn(
@@ -48,6 +51,7 @@ internal fun PlannerJourneyPlanScreen(
                 item {
                     PlanGroupItem(
                         day = planItem.day,
+                        startDate = startDate,
                         onClickEditRoute = {
                             onClickEditRoute.invoke(index)
                         },
@@ -66,6 +70,7 @@ internal fun PlannerJourneyPlanScreen(
                 item {
                     PlanEachTitle(
                         day = planItem.day,
+                        startDate = startDate,
                         onClickEditRoute = {
                             onClickEditRoute.invoke(index)
                         },
@@ -93,6 +98,7 @@ internal fun PlannerJourneyPlanScreen(
 @Composable
 private fun PlanGroupItem(
     day: Int,
+    startDate: Long,
     onClickEditRoute: () -> Unit,
 ) {
     Row(
@@ -118,7 +124,7 @@ private fun PlanGroupItem(
             )
             Spacer(modifier = Modifier.size(14.dp))
             JypText(
-                text = "7월 18일",
+                text = (startDate + TimeUnit.DAYS.toSeconds(day - 1L)).secondToDate("M월 d일"),
                 type = TextType.BODY_1,
                 color = JypColors.Text40,
             )
@@ -135,6 +141,7 @@ private fun PlanGroupItem(
 @Composable
 private fun PlanEachTitle(
     day: Int,
+    startDate: Long,
     onClickEditRoute: () -> Unit,
 ) {
     Row(
@@ -149,7 +156,7 @@ private fun PlanEachTitle(
             )
             Spacer(modifier = Modifier.size(14.dp))
             JypText(
-                text = "mm월 dd일",
+                text = (startDate + TimeUnit.DAYS.toSeconds(day - 1L)).secondToDate("M월 d일"),
                 type = TextType.BODY_1,
                 color = JypColors.Text40,
             )
@@ -357,6 +364,7 @@ private fun PlannerJourneyPlanScreenPreview() {
                 ),
             ),
         ),
+        startDate = 1523424321L,
         onClickEditRoute = {},
     )
 }

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerScreen.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerScreen.kt
@@ -33,6 +33,7 @@ import com.jyp.jyp_design.ui.typography.type.TextType
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun PlannerScreen(
+    plannerTitle: String,
     startDate: String,
     endDate: String,
     pikMes: List<PlannerPikme>,
@@ -55,7 +56,7 @@ internal fun PlannerScreen(
         appBar = {
             GlobalNavigationBar(
                 color = GlobalNavigationBarColor.BLACK,
-                title = "강릉 여행기",
+                title = plannerTitle,
                 activeBack = true,
                 backAction = onClickBackButton,
             )
@@ -239,6 +240,7 @@ private fun PlannerContentTab(
 @Preview(showBackground = true)
 internal fun PlannerScreenPreview() {
     PlannerScreen(
+        plannerTitle = "무슨 무슨 여행기~",
         startDate = "7월 22일",
         endDate = "7월 29일",
         pikMes = emptyList(),

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerScreen.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.jyp.core_util.extensions.secondToDate
 import com.jyp.feature_planner.R.*
 import com.jyp.feature_planner.domain.PlannerPikme
 import com.jyp.feature_planner.domain.PlannerTag
@@ -34,8 +35,8 @@ import com.jyp.jyp_design.ui.typography.type.TextType
 @Composable
 internal fun PlannerScreen(
     plannerTitle: String,
-    startDate: String,
-    endDate: String,
+    startDate: Long,
+    endDate: Long,
     pikMes: List<PlannerPikme>,
     joinMembers: List<String>,
     tags: List<PlannerTag>,
@@ -75,6 +76,7 @@ internal fun PlannerScreen(
                     stringResource(id = string.planner_tab_forum),
                     stringResource(id = string.planner_tab_piki),
                 ),
+                startDate = startDate,
                 selectedTabPosition = selectedTabPosition,
                 tabSelected = { selectedTabPosition = it },
                 pikMes = pikMes,
@@ -92,8 +94,8 @@ internal fun PlannerScreen(
 
 @Composable
 private fun PlannerBackLayer(
-    startDate: String,
-    endDate: String,
+    startDate: Long,
+    endDate: Long,
     profileImageUrls: List<String>,
     onClickInviteUserButton: () -> Unit,
 ) {
@@ -104,7 +106,7 @@ private fun PlannerBackLayer(
     ) {
         Spacer(modifier = Modifier.size(20.dp))
         JypText(
-            text = "$startDate - $endDate",
+            text = "${startDate.secondToDate("M월 d일")} - ${endDate.secondToDate("M월 d일")}",
             type = TextType.BODY_1,
             color = JypColors.Text_white,
         )
@@ -133,6 +135,7 @@ private fun PlannerBackLayer(
 @Composable
 private fun PlannerContent(
     tabTitles: List<String>,
+    startDate: Long,
     selectedTabPosition: Int,
     tabSelected: (position: Int) -> Unit,
     pikMes: List<PlannerPikme>,
@@ -170,6 +173,7 @@ private fun PlannerContent(
             )
             1 -> PlannerJourneyPlanScreen(
                 planItems = planItems,
+                startDate = startDate,
                 onClickEditRoute = onClickEditRoute,
             )
         }
@@ -241,8 +245,8 @@ private fun PlannerContentTab(
 internal fun PlannerScreenPreview() {
     PlannerScreen(
         plannerTitle = "무슨 무슨 여행기~",
-        startDate = "7월 22일",
-        endDate = "7월 29일",
+        startDate = 21312412L,
+        endDate = 21312412L,
         pikMes = emptyList(),
         joinMembers = emptyList(),
         tags = emptyList(),

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerViewModel.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerViewModel.kt
@@ -38,8 +38,8 @@ class PlannerViewModel @Inject constructor(
     val planItems: StateFlow<List<PlanItem>>
         get() = _planItems
 
-    private val _plannerDates = MutableStateFlow(Pair("", ""))
-    val plannerDates: StateFlow<Pair<String, String>>
+    private val _plannerDates = MutableStateFlow(Pair(0L, 0L))
+    val plannerDates: StateFlow<Pair<Long, Long>>
         get() = _plannerDates
 
     fun fetchPlannerData(id: String) {
@@ -60,8 +60,8 @@ class PlannerViewModel @Inject constructor(
                     }
 
                     _plannerDates.value = Pair(
-                        SimpleDateFormat("M월 d일", Locale.getDefault()).format(planner.startDate * 1000),
-                        SimpleDateFormat("M월 d일", Locale.getDefault()).format(planner.endDate * 1000),
+                        planner.startDate,
+                        planner.endDate,
                     )
 
                     _pikmis.value = planner.pikmis.map(pikmeMapper::toPlannerPikme)

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerViewModel.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/planner/PlannerViewModel.kt
@@ -18,6 +18,10 @@ import javax.inject.Inject
 class PlannerViewModel @Inject constructor(
     private val getPlannerUseCase: GetPlannerUseCase,
 ) : ViewModel() {
+    private val _plannerTitle = MutableStateFlow("")
+    val plannerTitle: StateFlow<String>
+        get() = _plannerTitle
+
     private val _pikmis = MutableStateFlow<List<PlannerPikme>>(emptyList())
     val pikmis: StateFlow<List<PlannerPikme>>
         get() = _pikmis
@@ -45,6 +49,8 @@ class PlannerViewModel @Inject constructor(
                     val tagMapper = PlannerTagMapper()
                     val pikiMapper = PlannerPikiMapper()
                     val pikmeMapper = PlannerPikmeMapper()
+
+                    _plannerTitle.value = planner.name
 
                     _tags.value = planner.tags.map(tagMapper::toPlannerTag)
                     _membersProfileUrl.value = planner.users.map { it.profileImagePath }


### PR DESCRIPTION
플래너 타이틀
여행 계획 날짜
여행 루트 날짜

세 군데 수정했어!

플래너 쪽은 태그 수정만 남은것 같아 아마도..?
태그 수정하는 부분은 초대쪽이랑 해서 작업 묶어 올리려고 해서 남겨두고 올릴게