### PR TITLE
#169: 나의 여행 카드 이미지 리사이징 처리 추가

### DIFF
--- a/feature_my_journey/src/main/java/com/jyp/feature_my_journey/presentation/my_journey/MyJourneyScreen.kt
+++ b/feature_my_journey/src/main/java/com/jyp/feature_my_journey/presentation/my_journey/MyJourneyScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultShadowColor
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -407,16 +408,14 @@ internal fun JourneyItem(
                 shape = RoundedCornerShape(16.dp)
             ),
     ) {
-        val painter = painterResource(themeType.imageRes)
-        val imageRatio = painter.intrinsicSize.width / painter.intrinsicSize.height
-
         Image(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(imageRatio)
-                .align(Alignment.BottomCenter),
-            painter = painter,
+                .align(Alignment.BottomCenter)
+                .clip(RoundedCornerShape(16.dp)),
+            painter = painterResource(themeType.imageRes),
             contentDescription = null,
+            contentScale = ContentScale.Crop
         )
 
         AvatarList(


### PR DESCRIPTION
화면 높이 작은 기기에서도 카드 이미지 제대로 보이도록 수정했습니다~!

![KakaoTalk_Photo_2023-04-16-16-42-29](https://user-images.githubusercontent.com/47806943/232281039-9dbb31e5-d8ab-401c-917f-b468642771db.jpeg)
