### PR TITLE
#198: 여행 루트 추가 헤더의 여행 일자 수정

### DIFF
--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteActivity.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteActivity.kt
@@ -52,7 +52,7 @@ private fun Screen(
 
     GlobalNavigationBarLayout(
         color = GlobalNavigationBarColor.WHITE,
-        title = "Day1",
+        title = "Day ${viewModel.dayIndex + 1}",
         titleFontWeight = FontWeight.SemiBold,
         titleSize = 20.sp,
         description = currentDate.secondToDate("M월 d일"),

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
@@ -21,7 +21,7 @@ class AddPlannerRouteViewModel @Inject constructor(
     private val setPikisUseCase: SetPikisUseCase,
 ) : ViewModel() {
     private val journeyId: String? = savedStateHandle[AddPlannerRouteActivity.EXTRA_JOURNEY_ID]
-    private val dayIndex: Int = savedStateHandle[AddPlannerRouteActivity.EXTRA_DAY_INDEX] ?: 0
+    val dayIndex: Int = savedStateHandle[AddPlannerRouteActivity.EXTRA_DAY_INDEX] ?: 0
 
     private val _pikmis =
         savedStateHandle.get<List<PlannerPikme>>(AddPlannerRouteActivity.EXTRA_PIKMIS)


### PR DESCRIPTION
<img width="707" alt="스크린샷 2023-04-21 오후 4 05 05" src="https://user-images.githubusercontent.com/47806943/233565256-23b144b8-7c75-47cb-8407-9e854b272b7c.png">
