### PR TITLE
#213: 루트 내 중복된 장소 삭제시 첫 번째 장소 삭제되는 문제 수정

### DIFF
--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteScreen.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteScreen.kt
@@ -33,7 +33,7 @@ internal fun AddPlannerRouteScreen(
     pikmis: List<PlannerPikme>,
     pikis: List<PlannerPiki>,
     onSelectPikme: (PlannerPikme) -> Unit,
-    onRemovePiki: (PlannerPiki) -> Unit,
+    onRemovePiki: (Int) -> Unit,
     onSubmitPikis: () -> Unit,
 ) {
     Column(
@@ -74,7 +74,7 @@ internal fun AddPlannerRouteScreen(
 @Composable
 private fun SelectedPikis(
     pikis: List<PlannerPiki>,
-    onRemovePiki: (PlannerPiki) -> Unit,
+    onRemovePiki: (Int) -> Unit,
 ) {
     LazyRow(
         modifier = Modifier
@@ -83,13 +83,14 @@ private fun SelectedPikis(
             .background(JypColors.Background_white200),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        items(pikis.size) { idx ->
+        items(pikis.size) { index ->
             SelectedPikiItem(
-                piki = pikis[idx],
+                index = index,
+                piki = pikis[index],
                 onRemovePiki = onRemovePiki,
             )
 
-            if (idx != pikis.lastIndex) {
+            if (index != pikis.lastIndex) {
                 SelectedPikiItemDivider()
             } else {
                 Spacer(modifier = Modifier.size(6.dp))
@@ -155,8 +156,9 @@ private fun SelectedPikisEmptyText() {
 
 @Composable
 private fun SelectedPikiItem(
+    index: Int,
     piki: PlannerPiki,
-    onRemovePiki: (PlannerPiki) -> Unit,
+    onRemovePiki: (Int) -> Unit,
 ) {
     Box {
         Column(
@@ -190,7 +192,7 @@ private fun SelectedPikiItem(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    onClick = { onRemovePiki.invoke(piki) },
+                    onClick = { onRemovePiki.invoke(index) }
                 ),
             painter = painterResource(id = R.drawable.icon_delete_journey_route),
             contentDescription = null,

--- a/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
+++ b/feature_planner/src/main/java/com/jyp/feature_planner/presentation/add_planner_route/AddPlannerRouteViewModel.kt
@@ -84,8 +84,10 @@ class AddPlannerRouteViewModel @Inject constructor(
         )
     }
 
-    fun removePiki(piki: PlannerPiki) {
-        _pikis.value -= piki
+    fun removePiki(index: Int) {
+        val mutablePikis = _pikis.value.toMutableList()
+        mutablePikis.removeAt(index)
+        _pikis.value = mutablePikis
     }
 
     fun setPikis() {


### PR DESCRIPTION
루트 내 중복된 장소 삭제시, 장소 인덱스에 무관하게 무조건 중복 중 첫 번째 장소가 삭제되는 문제가 있어 
이 부분 수정했습니다!